### PR TITLE
Add glfw package (#2742)

### DIFF
--- a/packages/glfw.rb
+++ b/packages/glfw.rb
@@ -1,0 +1,29 @@
+require 'package'
+
+class Glfw < Package                 # The first character of the class name must be upper case
+  description 'GLFW is a multi-platform library for OpenGL, OpenGL ES, Vulkan, window and input '
+  homepage 'http://www.glfw.org/'
+  version '3.2.1'
+  source_url 'https://github.com/glfw/glfw/archive/3.2.1.zip'
+  source_sha256 '0c623f65a129c424d0fa45591694fde3719ad4a0955d4835182fda71b255446f'   # Use the command "sha256sum"
+
+  depends_on 'cmake' => :build      # packages with "=> :build" are only required if you're building from source 
+
+  def self.build                   # the steps required to build the package
+    case ARCH
+    with 'x86_64'
+      system "cmake","-DCMAKE_INSTALL_PREFIX:PATH=#{CREW_PREFIX}", "-DCMAKE_LIB_SUFFIX=64"
+    else
+      system "cmake","-DCMAKE_INSTALL_PREFIX:PATH=#{CREW_PREFIX}"
+    end
+    system "make"
+  end
+
+  def self.install                 # the steps required to install the package
+    system "make", "DESTDIR=#{CREW_DEST_DIR}", "install"
+  end
+
+  def self.check                   # the steps required to check if the package was built ok
+    system "make", "check"
+  end
+end


### PR DESCRIPTION
* Add glfw package

* Added "-DCMAKE_LIB_SUFFIX=64"

* Made it so only "x86_64" chromebooks use "lib64"

Fixes #

(let GitHub automatically close an issue when this pull request gets merged)

## Before you submit a pull request
This template is not neccessary when you do simple things like updating packages to the latest version. But in doubt, it's always better so provide some information.

## Description
Provide a description, what your changes do and why they are important

Please link issues and other pull requests connected to this one.

## Addtional information
Mention things we might need to know. Like:

Works properly:
- [x] x86_64
- [ ] aarch64 (reasons why it doesn't)

---

## That's it
Thank you for submitting your pull request.
When done, please delete the parts of this template which you don't need or these, which are only for guidance.
